### PR TITLE
fix: now prettier works properly w/o changing LF/CRLF

### DIFF
--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -5,5 +5,6 @@
   "trailingComma": "es5",
   "printWidth": 100,
   "bracketSpacing": true,
-  "arrowParens": "avoid"
+  "arrowParens": "avoid",
+  "endOfLine": "auto"
 }

--- a/package.json
+++ b/package.json
@@ -33,8 +33,8 @@
   },
   "lint-staged": {
     "src/**/*.{js,jsx,ts,tsx}": [
-      "eslint --fix",
-      "prettier --write"
+      "prettier --write",
+      "eslint --fix"
     ],
     "src/**/*.{json,css,md}": "prettier --write"
   }


### PR DESCRIPTION
Fixato un problema di impostazioni di prettier per cui cambiava il "fine-riga" e git percepiva modifiche anche se effettivamente non c'erano