### PR TITLE
feat: add dockerfile and .dockerignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,11 @@
+Dockerfile
+.husky/
+.idea/
+node_modules/
+.git/
+.vscode/
+
+.dockerignore
+.gitignore
+.prettierrc.json
+eslint.config.js

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,14 @@
+FROM node:alpine
+LABEL authors="mich"
+
+WORKDIR /usr/src/app
+
+COPY package*.json .
+
+RUN npm ci
+
+COPY . .
+
+EXPOSE 5173
+
+CMD ["npm", "run", "dev", "--", "--host", "0.0.0.0"]


### PR DESCRIPTION
Aggiunto `dockerfile` con .ignore contestuale. Testato e funzionante. Essendo solo frontend "autoportante" non credo necessiti di compose.