### PR TITLE
feat: aggiunta anteprima stradale Mapillary con reverse geocoding

### DIFF
--- a/src/components/planner/InteractiveMap.jsx
+++ b/src/components/planner/InteractiveMap.jsx
@@ -9,6 +9,9 @@ import MapRoutePoints from './MapComponents/MapRoutePoints';
 import MapPolyline from './MapComponents/MapPolyline';
 import MapPOIs from './MapComponents/MapPOIs';
 import POICard from './POICard';
+import MapClickHandler from './MapComponents/MapClickHandler';
+import MapillaryPanel from './MapillaryPanel';
+import { FiEye } from 'react-icons/fi';
 
 delete L.Icon.Default.prototype._getIconUrl;
 L.Icon.Default.mergeOptions({
@@ -64,6 +67,8 @@ const InteractiveMap = ({
     const [centerTrigger, setCenterTrigger] = useState(0);
     const [mapLayer, setMapLayer] = useState('standard');
     const hasInitializedRef = useRef(false);
+    const [mapillaryPoint, setMapillaryPoint] = useState(null);
+    const [mapillaryMode, setMapillaryMode] = useState(false);
 
     const handleUserLocation = location => {
         setUserLocation(location);
@@ -217,6 +222,14 @@ const InteractiveMap = ({
                 </div>
             )}
 
+            {/* Mapillary Mode Tooltip */}
+            {mapillaryMode && (
+                <div className="absolute top-6 left-1/2 -translate-x-1/2 z-[1000] bg-blue-500 text-white px-4 py-2 rounded-xl shadow-lg text-sm font-medium flex items-center gap-2">
+                    <FiEye size={14} />
+                    Clicca sulla mappa per vedere le foto della zona
+                </div>
+            )}
+
             {/* Map Container */}
             <MapContainer
                 center={[45.4642, 9.19]}
@@ -244,6 +257,7 @@ const InteractiveMap = ({
                 <MapRoutePoints routePoints={routePointsWithLabels} />
                 <MapPolyline calculatedRoute={calculatedRoute} isScenicRoute={isScenicRoute} />
                 <MapPOIs pois={pois} onPoiClick={onPoiClick} />
+                <MapClickHandler onMapClick={setMapillaryPoint} mapillaryMode={mapillaryMode} />
             </MapContainer>
 
             {/* POI Card */}
@@ -252,6 +266,15 @@ const InteractiveMap = ({
                     poi={selectedPoi}
                     onClose={() => onPoiClick(null)}
                     onAddToRoute={onAddPoiToRoute}
+                />
+            )}
+
+            {/* Mapillary Panel */}
+            {mapillaryPoint && (
+                <MapillaryPanel
+                    lat={mapillaryPoint.lat}
+                    lon={mapillaryPoint.lng}
+                    onClose={() => setMapillaryPoint(null)}
                 />
             )}
 
@@ -277,6 +300,20 @@ const InteractiveMap = ({
                     </div>
                 </div>
             )}
+            {/* Mapillary Toggle Button */}
+            <button
+                onClick={() => setMapillaryMode(prev => !prev)}
+                className={`absolute bottom-6 right-6 z-[1000] w-12 h-12 rounded-2xl shadow-2xl
+        transition-all duration-300 border flex items-center justify-center
+        ${
+            mapillaryMode
+                ? 'bg-blue-500 text-white border-blue-400'
+                : 'bg-[#FAF7F2] text-gray-800 border-gray-200 hover:border-blue-400 hover:text-blue-500'
+        }`}
+                aria-label="Toggle Mapillary"
+            >
+                <FiEye size={20} />
+            </button>
         </div>
     );
 };

--- a/src/components/planner/MapComponents/MapClickHandler.jsx
+++ b/src/components/planner/MapComponents/MapClickHandler.jsx
@@ -1,0 +1,30 @@
+import { useMapEvents, useMap } from 'react-leaflet';
+import { useEffect } from 'react';
+
+const MapClickHandler = ({ onMapClick, mapillaryMode }) => {
+    const map = useMap();
+
+    useEffect(() => {
+        const container = map.getContainer();
+        if (mapillaryMode) {
+            container.style.cursor = 'crosshair';
+        } else {
+            container.style.cursor = '';
+        }
+        return () => {
+            container.style.cursor = '';
+        };
+    }, [mapillaryMode, map]);
+
+    useMapEvents({
+        click(e) {
+            if (mapillaryMode) {
+                onMapClick(e.latlng);
+            }
+        },
+    });
+
+    return null;
+};
+
+export default MapClickHandler;

--- a/src/components/planner/MapillaryPanel.jsx
+++ b/src/components/planner/MapillaryPanel.jsx
@@ -1,0 +1,130 @@
+import { useState, useEffect } from 'react';
+import { FiX, FiCamera, FiMapPin } from 'react-icons/fi';
+
+const MAPILLARY_TOKEN = import.meta.env.VITE_MAPILLARY_TOKEN;
+
+const MapillaryPanel = ({ lat, lon, onClose }) => {
+    const [photos, setPhotos] = useState([]);
+    const [loading, setLoading] = useState(true);
+    const [selectedPhoto, setSelectedPhoto] = useState(null);
+    const [address, setAddress] = useState(null);
+
+    useEffect(() => {
+        const fetchAddress = async () => {
+            try {
+                const response = await fetch(
+                    `https://nominatim.openstreetmap.org/reverse?lat=${lat}&lon=${lon}&format=json`,
+                    { headers: { 'Accept-Language': 'it' } }
+                );
+                const data = await response.json();
+                const road = data.address?.road || data.address?.pedestrian || data.address?.path;
+                const city = data.address?.city || data.address?.town || data.address?.village;
+                setAddress(
+                    road ? `${road}${city ? `, ${city}` : ''}` : city || 'Posizione sconosciuta'
+                );
+            } catch {
+                setAddress(null);
+            }
+        };
+
+        const fetchPhotos = async () => {
+            setLoading(true);
+            setPhotos([]);
+            setSelectedPhoto(null);
+
+            try {
+                const response = await fetch(
+                    `https://graph.mapillary.com/images?access_token=${MAPILLARY_TOKEN}&fields=id,thumb_256_url,thumb_1024_url,captured_at&bbox=${lon - 0.001},${lat - 0.001},${lon + 0.001},${lat + 0.001}&limit=10`
+                );
+                const data = await response.json();
+                if (data.data && data.data.length > 0) {
+                    setPhotos(data.data);
+                    setSelectedPhoto(data.data[0]);
+                }
+            } catch (error) {
+                console.error('Mapillary error:', error);
+            } finally {
+                setLoading(false);
+            }
+        };
+
+        fetchAddress();
+        fetchPhotos();
+    }, [lat, lon]);
+
+    return (
+        <div className="absolute bottom-6 right-6 z-[1500] w-96 bg-[#FAF7F2] rounded-2xl shadow-2xl border border-gray-200 overflow-hidden">
+            {/* Header */}
+            <div className="flex items-center justify-between px-4 py-3 border-b border-gray-200">
+                <div className="flex items-center gap-2 min-w-0">
+                    <FiCamera size={16} className="text-orange-500 flex-shrink-0" />
+                    <div className="min-w-0">
+                        <span className="text-sm font-semibold text-gray-800 block">
+                            Vista strada
+                        </span>
+                        {address ? (
+                            <span className="text-xs text-gray-500 flex items-center gap-1 truncate">
+                                <FiMapPin size={10} />
+                                {address}
+                            </span>
+                        ) : (
+                            <span className="text-xs text-gray-400">
+                                {lat.toFixed(4)}, {lon.toFixed(4)}
+                            </span>
+                        )}
+                    </div>
+                </div>
+                <button
+                    onClick={onClose}
+                    className="w-7 h-7 rounded-full hover:bg-gray-200 flex items-center justify-center transition-colors flex-shrink-0"
+                >
+                    <FiX size={14} className="text-gray-600" />
+                </button>
+            </div>
+
+            {/* Main photo */}
+            <div className="w-full h-52 bg-gray-100 flex items-center justify-center">
+                {loading ? (
+                    <div className="flex flex-col items-center gap-2">
+                        <div className="w-6 h-6 border-2 border-orange-500 border-t-transparent rounded-full animate-spin" />
+                        <span className="text-xs text-gray-500">Caricamento foto...</span>
+                    </div>
+                ) : selectedPhoto ? (
+                    <img
+                        src={selectedPhoto.thumb_1024_url}
+                        alt="Vista strada"
+                        className="w-full h-full object-cover"
+                    />
+                ) : (
+                    <div className="flex flex-col items-center gap-2 text-gray-400">
+                        <FiCamera size={32} />
+                        <span className="text-xs text-center px-4">
+                            Nessuna foto disponibile in questa zona
+                        </span>
+                    </div>
+                )}
+            </div>
+
+            {/* Thumbnails */}
+            {photos.length > 1 && (
+                <div className="flex gap-2 p-3 overflow-x-auto">
+                    {photos.map(photo => (
+                        <img
+                            key={photo.id}
+                            src={photo.thumb_256_url}
+                            alt="thumbnail"
+                            onClick={() => setSelectedPhoto(photo)}
+                            className={`w-14 h-14 object-cover rounded-lg cursor-pointer flex-shrink-0 transition-all ${
+                                selectedPhoto?.id === photo.id
+                                    ? 'ring-2 ring-orange-500'
+                                    : 'opacity-70 hover:opacity-100'
+                            }`}
+                        />
+                    ))}
+                </div>
+            )}
+        </div>
+    );
+};
+
+export default MapillaryPanel;


### PR DESCRIPTION
##Cosa è stato aggiunto
Integrazione di Mapillary per visualizzare foto stradali direttamente sulla mappa.

## Come funziona
- Bottone occhio in basso a destra attiva la modalità street view
- Quando attivo, il cursore diventa un mirino e appare un tooltip guida
- Cliccando sulla mappa appare un pannello con le foto della zona
- Il pannello mostra il nome della via tramite reverse geocoding (Nominatim)
- Le thumbnail permettono di sfogliare le foto disponibili

## File aggiunti
- `MapClickHandler.jsx` — gestisce il click sulla mappa
- `MapillaryPanel.jsx` — pannello con foto e indirizzo