### PR TITLE
feat: implement manual route with waypoint markers and map auto-recenter

### DIFF
--- a/src/components/planner/InteractiveMap.jsx
+++ b/src/components/planner/InteractiveMap.jsx
@@ -24,7 +24,6 @@ L.Icon.Default.mergeOptions({
 const MapController = ({ center, route, centerTrigger }) => {
     const map = useMap();
     const lastTriggerRef = useRef(0);
-    const hasCenteredOnRouteRef = useRef(false);
 
     useEffect(() => {
         if (center && centerTrigger > lastTriggerRef.current) {
@@ -37,14 +36,13 @@ const MapController = ({ center, route, centerTrigger }) => {
     }, [center, map, centerTrigger]);
 
     useEffect(() => {
-        if (route?.length > 1 && !hasCenteredOnRouteRef.current) {
+        if (route?.length > 1) {
             const bounds = L.latLngBounds(route);
             map.flyToBounds(bounds, {
                 padding: [50, 50],
                 duration: 1.5,
                 maxZoom: 14,
             });
-            hasCenteredOnRouteRef.current = true;
         }
     }, [route, map]);
 

--- a/src/components/planner/MapComponents/MapRoutePoints.jsx
+++ b/src/components/planner/MapComponents/MapRoutePoints.jsx
@@ -2,6 +2,33 @@ import { Marker, Popup } from 'react-leaflet';
 import { FiMapPin } from 'react-icons/fi';
 import L from 'leaflet';
 
+// Colori marker stile Google Maps
+const COLORS = {
+    start: '#1a73e8', // blu Google
+    end: '#ea4335', // rosso Google
+    waypoint: '#1a73e8', // blu Google
+};
+
+const createPinIcon = (color, label = '', className = 'map-pin-marker') => {
+    const inner = label
+        ? `<text x="12" y="15" text-anchor="middle" fill="white" font-size="10" font-weight="bold" font-family="sans-serif">${label}</text>`
+        : `<circle cx="12" cy="12" r="4" fill="white"/>`;
+
+    return L.divIcon({
+        className,
+        html: `
+          <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 36" width="24" height="36"
+               style="filter: drop-shadow(0 2px 4px rgba(0,0,0,0.4));">
+            <path d="M12 0C5.4 0 0 5.4 0 12c0 7.2 12 24 12 24S24 19.2 24 12C24 5.4 18.6 0 12 0z"
+                  fill="${color}"/>
+            ${inner}
+          </svg>
+        `,
+        iconSize: [24, 36],
+        iconAnchor: [12, 36],
+    });
+};
+
 const MapRoutePoints = ({ routePoints }) => {
     if (!routePoints || routePoints.length === 0) return null;
 
@@ -11,84 +38,33 @@ const MapRoutePoints = ({ routePoints }) => {
                 const position = point.position || [45.4642, 9.19];
                 const isStart = index === 0;
                 const isEnd = index === routePoints.length - 1;
-                let customIcon = null;
 
+                let icon;
+                let popupColor;
                 if (isStart) {
-                    customIcon = L.divIcon({
-                        className: 'start-marker',
-                        html: `
-              <div style="
-                width: 20px;
-                height: 20px;
-                background-color: white;
-                border: 3px solid black;
-                border-radius: 50%;
-                box-shadow: 0 2px 4px rgba(0,0,0,0.3);
-              "></div>
-            `,
-                        iconSize: [20, 20],
-                        iconAnchor: [10, 10],
-                    });
+                    icon = createPinIcon(COLORS.start, '', 'start-marker');
+                    popupColor = 'text-blue-600';
                 } else if (isEnd) {
-                    customIcon = L.divIcon({
-                        className: 'end-marker',
-                        html: `
-              <div style="
-                position: relative;
-                width: 24px;
-                height: 32px;
-              ">
-                <div style="
-                  position: absolute;
-                  top: 0;
-                  left: 50%;
-                  transform: translateX(-50%);
-                  width: 16px;
-                  height: 16px;
-                  background-color: #ea4335;
-                  border-radius: 50% 50% 50% 0;
-                  transform: translateX(-50%) rotate(-45deg);
-                  border: 3px solid white;
-                  box-shadow: 0 2px 4px rgba(0,0,0,0.3);
-                "></div>
-                <div style="
-                  position: absolute;
-                  bottom: 0;
-                  left: 50%;
-                  transform: translateX(-50%);
-                  width: 6px;
-                  height: 12px;
-                  background-color: #ea4335;
-                  border: 2px solid white;
-                  border-top: none;
-                  border-radius: 0 0 2px 2px;
-                "></div>
-              </div>
-            `,
-                        iconSize: [24, 32],
-                        iconAnchor: [12, 32],
-                    });
+                    icon = createPinIcon(COLORS.end, '', 'end-marker');
+                    popupColor = 'text-red-600';
+                } else {
+                    icon = createPinIcon(COLORS.waypoint, String(index), 'waypoint-marker');
+                    popupColor = 'text-sky-500';
                 }
 
                 return (
-                    <Marker
-                        key={index}
-                        position={position}
-                        icon={customIcon || undefined} // undefined => usa icona di default
-                    >
+                    <Marker key={index} position={position} icon={icon}>
                         <Popup>
                             <div className="flex flex-col">
                                 <div className="flex items-center gap-2 mb-2">
-                                    <FiMapPin
-                                        className={`${isStart ? 'text-gray-800' : isEnd ? 'text-red-600' : 'text-orange-500'}`}
-                                    />
+                                    <FiMapPin className={popupColor} />
                                     <span className="font-bold text-gray-900">
                                         {point.label ||
                                             (isStart
                                                 ? 'Partenza'
                                                 : isEnd
                                                   ? 'Arrivo'
-                                                  : `Punto ${index + 1}`)}
+                                                  : `Tappa ${index}`)}
                                     </span>
                                 </div>
                                 <div className="text-gray-600 text-sm">

--- a/src/pages/Planner.jsx
+++ b/src/pages/Planner.jsx
@@ -80,6 +80,7 @@ const Planner = () => {
     const [loading, setLoading] = useState(false);
     const [loadingPois, setLoadingPois] = useState(false);
     const [routeDetails, setRouteDetails] = useState(null);
+    const [waypointMarkers, setWaypointMarkers] = useState([]);
     const [errorMessage, setErrorMessage] = useState(null);
     const [successMessage, setSuccessMessage] = useState(null);
     const [selectedPoi, setSelectedPoi] = useState(null);
@@ -226,8 +227,118 @@ const Planner = () => {
         setSelectedPoi(null);
     };
 
-    const handleCalculateRoute = formData => {
-        console.log('Manual route requested:', formData);
+    const handleCalculateRoute = async formData => {
+        if (!formData.startPoint || !formData.endPoint) {
+            showError('Inserisci punto di partenza e arrivo');
+            return;
+        }
+
+        if (loading) return;
+        setLoading(true);
+        setErrorMessage(null);
+
+        try {
+            setIsScenicRoute(false);
+            setCalculatedRoute([]);
+            setRouteStats(null);
+            setPois([]);
+            setRouteDetails(null);
+            setWaypointMarkers([]);
+
+            const filteredWaypoints = (formData.waypoints || []).filter(w => w.trim() !== '');
+
+            const payload = {
+                start_location_name: formData.startPoint.trim(),
+                end_location_name: formData.endPoint.trim(),
+                ...(filteredWaypoints.length > 0 && { waypoints: filteredWaypoints }),
+            };
+
+            const response = await fetch(`${API_BASE_URL}/api/routes/calculate-fastest/`, {
+                method: 'POST',
+                headers: {
+                    'Content-Type': 'application/json',
+                    Accept: 'application/json',
+                },
+                body: JSON.stringify(payload),
+                mode: 'cors',
+            });
+
+            if (!response.ok) {
+                const errorText = await response.text();
+                let errorMessage = `Errore ${response.status}`;
+                try {
+                    const errorData = JSON.parse(errorText);
+                    errorMessage = errorData.error || errorData.details || errorMessage;
+                } catch {
+                    // keep default message
+                }
+                throw new Error(errorMessage);
+            }
+
+            const result = await response.json();
+
+            const routeCoords = decodePolyline(result.polyline);
+
+            if (routeCoords.length === 0) {
+                if (result.start_coordinates) {
+                    routeCoords.push([result.start_coordinates.lat, result.start_coordinates.lon]);
+                }
+                if (result.end_coordinates) {
+                    routeCoords.push([result.end_coordinates.lat, result.end_coordinates.lon]);
+                }
+            }
+
+            setCalculatedRoute(routeCoords);
+            setRouteStats({
+                distance: formatDistance(result.total_distance_km),
+                duration: formatTime(result.total_time_minutes),
+            });
+            setRouteDetails({
+                ...result,
+                startAddress: result.start_location || formData.startPoint,
+                endAddress: result.end_location || formData.endPoint,
+                formData,
+            });
+
+            // Geocodifica le tappe intermedie per ottenere le coordinate dei marker
+            const nonEmptyWaypoints = filteredWaypoints;
+            if (nonEmptyWaypoints.length > 0) {
+                const markers = await Promise.all(
+                    nonEmptyWaypoints.map(async (name, i) => {
+                        try {
+                            const geo = await fetch(
+                                `${API_BASE_URL}/api/geocode/search/?q=${encodeURIComponent(name)}&limit=1`,
+                                { headers: { Accept: 'application/json' } }
+                            );
+                            if (!geo.ok) return null;
+                            const [place] = await geo.json();
+                            if (!place) return null;
+                            return {
+                                position: [parseFloat(place.lat), parseFloat(place.lon)],
+                                label: `Tappa ${i + 1}`,
+                                description: place.display_name || name,
+                            };
+                        } catch {
+                            return null;
+                        }
+                    })
+                );
+                setWaypointMarkers(markers.filter(Boolean));
+            } else {
+                setWaypointMarkers([]);
+            }
+        } catch (error) {
+            console.error('Error calculating fastest route:', error);
+            let msg = 'Errore nel calcolo del percorso';
+            if (error.message.includes('Failed to fetch')) {
+                msg = 'Connessione fallita. Il backend è in esecuzione?';
+            } else {
+                msg = error.message;
+            }
+            showError(msg);
+        } finally {
+            setLoading(false);
+        }
     };
 
     const handleCalculateScenicRoute = async formData => {
@@ -244,6 +355,7 @@ const Planner = () => {
             setIsScenicRoute(true);
             setCalculatedRoute([]);
             setRouteStats(null);
+            setWaypointMarkers([]);
             setPois([]);
             setRouteDetails(null);
 
@@ -443,7 +555,7 @@ const Planner = () => {
 
             <InteractiveMap
                 onMenuToggle={() => setIsMenuOpen(!isMenuOpen)}
-                routePoints={[]}
+                routePoints={waypointMarkers}
                 calculatedRoute={calculatedRoute}
                 pois={displayPois}
                 routeStats={routeStats}


### PR DESCRIPTION
 Il tasto "Manuale" nel planner non faceva nulla, era rimasto un placeholder. L'ho implementato: chiama                
  /api/routes/calculate-fastest/ con partenza, arrivo e tappe opzionali, e disegna il percorso sulla mappa.             
                                                                                                                        
  Ho aggiunto anche i marker per le tappe intermedie — cerchi arancioni numerati. Il backend non restituisce le         
  coordinate delle tappe nella risposta, quindi le geocodifico separatamente solo per i marker.                         
                                                                                                                        
  Fix anche alla mappa che non si ri-centrava quando calcolavi un secondo percorso diverso dal primo.

  File toccati:
  - src/pages/Planner.jsx
  - src/components/planner/MapComponents/MapRoutePoints.jsx
  - src/components/planner/InteractiveMap.jsx