### PR TITLE
fix: satellite screenshot via ArcGIS static export + route centering …

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,6 @@
         "@tailwindcss/vite": "^4.1.18",
         "axios": "^1.13.5",
         "framer-motion": "^12.34.1",
-        "html2canvas": "^1.4.1",
         "leaflet": "^1.9.4",
         "react": "^19.2.0",
         "react-dom": "^19.2.0",
@@ -1866,15 +1865,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/base64-arraybuffer": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/base64-arraybuffer/-/base64-arraybuffer-1.0.2.tgz",
-      "integrity": "sha512-I3yl4r9QB5ZRY3XuJVEPfc2XhZO6YweFPI+UovAzn+8/hb3oJ6lnysaFcjVpkCPfVWFUDvoZ8kmVDP7WyRtYtQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.6.0"
-      }
-    },
     "node_modules/baseline-browser-mapping": {
       "version": "2.9.5",
       "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.9.5.tgz",
@@ -2153,15 +2143,6 @@
       },
       "engines": {
         "node": ">= 8"
-      }
-    },
-    "node_modules/css-line-break": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/css-line-break/-/css-line-break-2.1.0.tgz",
-      "integrity": "sha512-FHcKFCZcAha3LwfVBhCQbW2nCNbkZXn7KVUJcsT5/P8YmfsVja0FMPJr0B903j/E69HUphKiV9iQArX8SDYA4w==",
-      "license": "MIT",
-      "dependencies": {
-        "utrie": "^1.0.2"
       }
     },
     "node_modules/csstype": {
@@ -3008,19 +2989,6 @@
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
       "license": "ISC"
-    },
-    "node_modules/html2canvas": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/html2canvas/-/html2canvas-1.4.1.tgz",
-      "integrity": "sha512-fPU6BHNpsyIhr8yyMpTLLxAbkaK8ArIBcmZIRiBLiDhjeqvXolaEmDGmELFuX9I4xDcaKKcJl+TKZLqruBbmWA==",
-      "license": "MIT",
-      "dependencies": {
-        "css-line-break": "^2.1.0",
-        "text-segmentation": "^1.0.3"
-      },
-      "engines": {
-        "node": ">=8.0.0"
-      }
     },
     "node_modules/husky": {
       "version": "9.1.7",
@@ -4706,15 +4674,6 @@
         "url": "https://opencollective.com/webpack"
       }
     },
-    "node_modules/text-segmentation": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/text-segmentation/-/text-segmentation-1.0.3.tgz",
-      "integrity": "sha512-iOiPUo/BGnZ6+54OsWxZidGCsdU8YbE4PSpdPinp7DeMtUJNJBoJ/ouUSTJjHkh1KntHaltHl/gDs2FC4i5+Nw==",
-      "license": "MIT",
-      "dependencies": {
-        "utrie": "^1.0.2"
-      }
-    },
     "node_modules/tinyglobby": {
       "version": "0.2.15",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
@@ -4823,15 +4782,6 @@
       "license": "BSD-2-Clause",
       "dependencies": {
         "punycode": "^2.1.0"
-      }
-    },
-    "node_modules/utrie": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/utrie/-/utrie-1.0.2.tgz",
-      "integrity": "sha512-1MLa5ouZiOmQzUbjbu9VmjLzn1QLXBhwpUa7kdLUQK+KQ5KA9I1vk5U4YHe/X2Ch7PYnJfWuWT+VbuxbGwljhw==",
-      "license": "MIT",
-      "dependencies": {
-        "base64-arraybuffer": "^1.0.2"
       }
     },
     "node_modules/validate-npm-package-license": {

--- a/package.json
+++ b/package.json
@@ -18,7 +18,6 @@
     "@tailwindcss/vite": "^4.1.18",
     "axios": "^1.13.5",
     "framer-motion": "^12.34.1",
-    "html2canvas": "^1.4.1",
     "leaflet": "^1.9.4",
     "react": "^19.2.0",
     "react-dom": "^19.2.0",

--- a/src/components/planner/InteractiveMap.jsx
+++ b/src/components/planner/InteractiveMap.jsx
@@ -21,19 +21,23 @@ L.Icon.Default.mergeOptions({
 });
 
 // Auto-centers the map on the user's location once on first mount
-const MapAutoCenter = ({ userLocation }) => {
+const MapAutoCenter = ({ userLocation, hasRoute }) => {
     const map = useMap();
     const hasCenteredRef = useRef(false);
 
     useEffect(() => {
-        if (userLocation && !hasCenteredRef.current) {
+        if (!hasRoute) hasCenteredRef.current = false;
+    }, [hasRoute]);
+
+    useEffect(() => {
+        if (userLocation && !hasCenteredRef.current && !hasRoute) {
             map.flyTo(userLocation, 15, {
                 duration: 1.5,
                 easeLinearity: 0.25,
             });
             hasCenteredRef.current = true;
         }
-    }, [userLocation, map]);
+    }, [userLocation, map, hasRoute]);
 
     return null;
 };
@@ -44,6 +48,11 @@ const MapController = ({ center, route, centerTrigger, onRouteRendered }) => {
     const lastTriggerRef = useRef(0);
     const hasCenteredOnRouteRef = useRef(false);
     const timeoutRef = useRef();
+    const onRouteRenderedRef = useRef(onRouteRendered);
+
+    useEffect(() => {
+        onRouteRenderedRef.current = onRouteRendered;
+    }, [onRouteRendered]);
 
     useEffect(() => {
         if (center && centerTrigger > lastTriggerRef.current) {
@@ -72,9 +81,7 @@ const MapController = ({ center, route, centerTrigger, onRouteRendered }) => {
             const onMoveEnd = () => {
                 map.off('moveend', onMoveEnd);
                 timeoutRef.current = setTimeout(() => {
-                    if (onRouteRendered && typeof onRouteRendered === 'function') {
-                        onRouteRendered();
-                    }
+                    onRouteRenderedRef.current?.();
                 }, 200);
             };
             map.on('moveend', onMoveEnd);
@@ -86,7 +93,7 @@ const MapController = ({ center, route, centerTrigger, onRouteRendered }) => {
                 }
             };
         }
-    }, [route, map, onRouteRendered]);
+    }, [route, map]);
 
     return null;
 };
@@ -277,7 +284,7 @@ const InteractiveMap = ({
                 scrollWheelZoom={true}
                 zoomControl={false}
             >
-                <MapAutoCenter userLocation={userLocation} />
+                <MapAutoCenter userLocation={userLocation} hasRoute={calculatedRoute.length > 0} />
                 <MapController
                     center={userLocation}
                     route={calculatedRoute}
@@ -292,6 +299,7 @@ const InteractiveMap = ({
                             : 'https://server.arcgisonline.com/ArcGIS/rest/services/World_Imagery/MapServer/tile/{z}/{y}/{x}'
                     }
                     attribution='&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a>'
+                    crossOrigin="anonymous"
                 />
 
                 <MapUserLocation onLocationFound={handleUserLocation} />

--- a/src/pages/MyTours.jsx
+++ b/src/pages/MyTours.jsx
@@ -255,7 +255,7 @@ function RoutesGrid() {
                 className="py-10 pb-20"
                 style={{ paddingLeft: sectionPadding, paddingRight: sectionPadding }}
             >
-                <div className="max-w-7xl xl:max-w-screen-2xl mx-auto">
+                <div className="max-w-4xl mx-auto">
                     {/* Suspension banner */}
                     {isUserSuspended && (
                         <div
@@ -271,7 +271,7 @@ function RoutesGrid() {
                     )}
 
                     {/* Grid */}
-                    <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 2xl:grid-cols-5 gap-4 sm:gap-5">
+                    <div className="grid grid-cols-1 sm:grid-cols-2 gap-4 sm:gap-6">
                         {routes.length === 0 && (
                             <div className="col-span-full text-center py-20 animate-fadeUp">
                                 <div
@@ -425,9 +425,7 @@ function RouteCard({
     };
 
     const area = `${route.start_location_name || '?'} → ${route.end_location_name || '?'}`;
-    const image = route.screenshot
-        ? new URL(route.screenshot, MEDIA_BASE_URL).toString()
-        : `https://picsum.photos/seed/${route.id}/300/400`;
+    const image = route.screenshot ? new URL(route.screenshot, MEDIA_BASE_URL).toString() : null;
     const isPublic = route.visibility === 'public';
 
     return (
@@ -443,12 +441,14 @@ function RouteCard({
             style={{ animationDelay: `${idx * 0.05}s` }}
         >
             {/* Image */}
-            <div className="relative aspect-4/3 overflow-hidden bg-[#EDE9DF]">
-                <img
-                    src={image}
-                    alt={route.name}
-                    className="w-full h-full object-cover transition-transform duration-600 group-hover:scale-[1.04]"
-                />
+            <div className="relative aspect-video overflow-hidden bg-[#EDE9DF]">
+                {image && (
+                    <img
+                        src={image}
+                        alt={route.name}
+                        className="w-full h-full object-cover transition-transform duration-600 group-hover:scale-[1.04]"
+                    />
+                )}
                 <div className="absolute inset-0 bg-linear-to-b from-transparent to-black/25 pointer-events-none" />
 
                 {/* Toggle */}

--- a/src/pages/Planner.jsx
+++ b/src/pages/Planner.jsx
@@ -1,6 +1,5 @@
 import { useState, useEffect, useCallback } from 'react';
 import { useLocation } from 'react-router-dom';
-import html2canvas from 'html2canvas';
 import InteractiveMap from '../components/planner/InteractiveMap';
 import PlannerForm from '../components/planner/PlannerForm';
 import { poiService } from '../components/planner/MapServices/POIService.jsx';
@@ -159,6 +158,12 @@ const Planner = () => {
             applyRouteData(routeData);
         }
     }, [routeData]);
+
+    useEffect(() => {
+        if (calculatedRoute.length > 0) {
+            captureRouteScreenshot();
+        }
+    }, [calculatedRoute, isScenicRoute]); // eslint-disable-line react-hooks/exhaustive-deps
 
     const applyRouteData = data => {
         const coords = decodePolyline(data.polyline);
@@ -375,58 +380,122 @@ const Planner = () => {
     };
 
     const captureRouteScreenshot = useCallback(async () => {
-        if (!calculatedRoute || calculatedRoute.length === 0) {
-            throw new Error('Il percorso selezionato non è valido o è vuoto.');
-        }
+        if (!calculatedRoute || calculatedRoute.length === 0) return;
+
+        const W = 600;
+        const H = 400;
+        const mainColor = isScenicRoute ? '#2563eb' : '#f97316';
+        const outlineColor = isScenicRoute ? '#1e3a8a' : '#c2410c';
 
         try {
-            const previousLayer = mapLayer;
+            const lats = calculatedRoute.map(([lat]) => lat);
+            const lons = calculatedRoute.map(([, lon]) => lon);
+            const minLat = Math.min(...lats);
+            const maxLat = Math.max(...lats);
+            const minLon = Math.min(...lons);
+            const maxLon = Math.max(...lons);
+            const latPad = (maxLat - minLat) * 0.25;
+            const lonPad = (maxLon - minLon) * 0.25;
+            let bMinLon = minLon - lonPad;
+            let bMinLat = minLat - latPad;
+            let bMaxLon = maxLon + lonPad;
+            let bMaxLat = maxLat + latPad;
 
-            if (mapLayer !== 'satellite') {
-                setMapLayer('satellite');
-                await new Promise(resolve => setTimeout(resolve, 500));
+            // Adjust bbox to match canvas aspect ratio to avoid distortion
+            const cosLat = Math.cos(((bMinLat + bMaxLat) / 2) * (Math.PI / 180));
+            const bboxAspect = ((bMaxLon - bMinLon) * cosLat) / (bMaxLat - bMinLat);
+            const canvasAspect = W / H;
+            if (bboxAspect > canvasAspect) {
+                const newLatSpan = ((bMaxLon - bMinLon) * cosLat) / canvasAspect;
+                const latCenter = (bMinLat + bMaxLat) / 2;
+                bMinLat = latCenter - newLatSpan / 2;
+                bMaxLat = latCenter + newLatSpan / 2;
+            } else {
+                const newLonSpan = ((bMaxLat - bMinLat) * canvasAspect) / cosLat;
+                const lonCenter = (bMinLon + bMaxLon) / 2;
+                bMinLon = lonCenter - newLonSpan / 2;
+                bMaxLon = lonCenter + newLonSpan / 2;
             }
 
-            const mapElement = document.querySelector('.leaflet-container');
-            if (!mapElement) {
-                console.warn('Elemento mappa non trovato');
-                return;
-            }
-
-            // Hide markers POI
-            const poiMarkers = document.querySelectorAll('.leaflet-marker-icon');
-            poiMarkers.forEach(marker => {
-                marker.style.visibility = 'hidden';
+            const bboxStr = `${bMinLon},${bMinLat},${bMaxLon},${bMaxLat}`;
+            const res = await fetch(
+                `https://server.arcgisonline.com/ArcGIS/rest/services/World_Street_Map/MapServer/export?bbox=${bboxStr}&bboxSR=4326&size=${W},${H}&imageSR=4326&format=jpg&f=image`
+            );
+            const blob = await res.blob();
+            const objectUrl = URL.createObjectURL(blob);
+            const img = new Image();
+            await new Promise((resolve, reject) => {
+                img.onload = resolve;
+                img.onerror = reject;
+                img.src = objectUrl;
             });
+            URL.revokeObjectURL(objectUrl);
 
-            await new Promise(resolve => requestAnimationFrame(resolve));
-            await new Promise(resolve => setTimeout(resolve, 300));
+            const canvas = document.createElement('canvas');
+            canvas.width = W;
+            canvas.height = H;
+            const ctx = canvas.getContext('2d');
+            ctx.drawImage(img, 0, 0, W, H);
 
-            const canvas = await html2canvas(mapElement, {
-                scale: 1.5,
-                backgroundColor: '#1a1a1a',
-                allowTaint: false,
-                useCORS: true,
-                logging: false,
-            });
+            const toPixel = (lat, lon) => [
+                ((lon - bMinLon) / (bMaxLon - bMinLon)) * W,
+                ((bMaxLat - lat) / (bMaxLat - bMinLat)) * H,
+            ];
 
-            // Restore markers
-            poiMarkers.forEach(marker => {
-                marker.style.visibility = 'visible';
-            });
+            const traceRoute = () => {
+                ctx.beginPath();
+                calculatedRoute.forEach(([lat, lon], i) => {
+                    const [x, y] = toPixel(lat, lon);
+                    i === 0 ? ctx.moveTo(x, y) : ctx.lineTo(x, y);
+                });
+            };
 
-            const screenshotBase64 = canvas.toDataURL('image/jpeg', 0.9);
-            setRouteScreenshot(screenshotBase64);
-            console.log('Screenshot catturato con mappa satellitare');
+            // Outline then main line
+            traceRoute();
+            ctx.strokeStyle = outlineColor;
+            ctx.lineWidth = 6;
+            ctx.lineJoin = 'round';
+            ctx.lineCap = 'round';
+            ctx.stroke();
 
-            // Restore previous layer if different
-            if (previousLayer !== 'satellite') {
-                setMapLayer(previousLayer);
-            }
-        } catch (error) {
-            console.error('Errore nella cattura dello screenshot:', error);
+            traceRoute();
+            ctx.strokeStyle = mainColor;
+            ctx.lineWidth = 4;
+            ctx.lineJoin = 'round';
+            ctx.lineCap = 'round';
+            ctx.stroke();
+
+            // Start / end markers
+            const drawMarker = (lat, lon, label) => {
+                const [x, y] = toPixel(lat, lon);
+                const r = 12;
+                ctx.beginPath();
+                ctx.arc(x, y, r, 0, Math.PI * 2);
+                ctx.fillStyle = 'white';
+                ctx.fill();
+                ctx.strokeStyle = mainColor;
+                ctx.lineWidth = 2.5;
+                ctx.stroke();
+                ctx.fillStyle = mainColor;
+                ctx.font = `bold ${r}px sans-serif`;
+                ctx.textAlign = 'center';
+                ctx.textBaseline = 'middle';
+                ctx.fillText(label, x, y);
+            };
+
+            const [startLat, startLon] = calculatedRoute[0];
+            const [endLat, endLon] = calculatedRoute[calculatedRoute.length - 1];
+            drawMarker(startLat, startLon, 'A');
+            drawMarker(endLat, endLon, 'B');
+
+            const base64 = canvas.toDataURL('image/jpeg', 0.7);
+            setRouteScreenshot(base64);
+            return base64;
+        } catch (err) {
+            console.error('Screenshot error:', err);
+            return null;
         }
-    }, [calculatedRoute]);
+    }, [calculatedRoute, isScenicRoute]);
 
     const handleCalculateScenicRoute = async formData => {
         if (!formData.startPoint || !formData.endPoint) {
@@ -566,6 +635,8 @@ const Planner = () => {
                 throw new Error('Utente non autenticato. Effettua il login.');
             }
 
+            const screenshot = routeScreenshot || (await captureRouteScreenshot());
+
             const payload = {
                 name:
                     formData.routeName || `Percorso panoramico ${new Date().toLocaleDateString()}`,
@@ -580,8 +651,8 @@ const Planner = () => {
                     total_scenic_score: routeDetails.scenic_route?.scenic_score || 0,
                 },
             };
-            if (routeScreenshot) {
-                payload.screenshot = routeScreenshot;
+            if (screenshot) {
+                payload.screenshot = screenshot;
             }
 
             const response = await fetch(`${API_BASE_URL}/api/routes/save-calculated/`, {
@@ -597,15 +668,15 @@ const Planner = () => {
 
             if (!response.ok) {
                 const errorText = await response.text();
+                console.error('Save route response:', response.status, errorText);
                 let errorMessage = 'Errore nel salvataggio del percorso';
                 try {
                     const errorData = JSON.parse(errorText);
-                    errorMessage = errorData.error || errorData.detail || errorMessage;
-                } catch (parseError) {
-                    console.error('Error parsing save response:', parseError);
-                }
-                if (response.status === 409) {
-                    errorMessage = 'Percorso già salvato in precedenza.';
+                    const nonFieldErrors = errorData.non_field_errors?.[0];
+                    errorMessage =
+                        nonFieldErrors || errorData.error || errorData.detail || errorMessage;
+                } catch {
+                    errorMessage = errorText || errorMessage;
                 }
                 throw new Error(errorMessage);
             }
@@ -655,7 +726,7 @@ const Planner = () => {
                 selectedPoi={selectedPoi}
                 onPoiClick={handlePoiClick}
                 onAddPoiToRoute={handleAddPoiToRoute}
-                onRouteRendered={captureRouteScreenshot}
+                onRouteRendered={null}
                 mapLayer={mapLayer}
                 onMapLayerChange={setMapLayer}
                 centerOnUserLocation={shouldCenterOnUser}

--- a/src/pages/Tour.jsx
+++ b/src/pages/Tour.jsx
@@ -190,7 +190,7 @@ function RoutesGrid() {
                 className="py-10 pb-20"
                 style={{ paddingLeft: sectionPadding, paddingRight: sectionPadding }}
             >
-                <div className="max-w-7xl xl:max-w-screen-2xl mx-auto">
+                <div className="max-w-4xl mx-auto">
                     {routes.length === 0 && (
                         <div className="text-center py-20 animate-fadeUp">
                             <div className="w-14 h-14 rounded-2xl bg-[#EDE9DF] flex items-center justify-center mx-auto mb-4 text-[#9B958F]">
@@ -218,7 +218,7 @@ function RoutesGrid() {
                         </div>
                     )}
 
-                    <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 2xl:grid-cols-5 gap-4 sm:gap-5">
+                    <div className="grid grid-cols-1 sm:grid-cols-2 gap-4 sm:gap-6">
                         {routes.map((route, idx) => (
                             <RouteCard
                                 key={route.id}
@@ -315,9 +315,7 @@ function RouteCard({ route, idx, isAdmin, banningRouteId, onBan }) {
     };
 
     const area = `${route.start_location_name || '?'} → ${route.end_location_name || '?'}`;
-    const image = route.screenshot
-        ? new URL(route.screenshot, MEDIA_BASE_URL).toString()
-        : `https://picsum.photos/seed/${route.id}/300/400`;
+    const image = route.screenshot ? new URL(route.screenshot, MEDIA_BASE_URL).toString() : null;
     const owner = route.owner_username || 'Anonymous';
 
     return (
@@ -332,12 +330,14 @@ function RouteCard({ route, idx, isAdmin, banningRouteId, onBan }) {
             style={{ animationDelay: `${idx * 0.05}s` }}
         >
             {/* Image */}
-            <div className="relative aspect-4/3 overflow-hidden bg-[#EDE9DF]">
-                <img
-                    src={image}
-                    alt={route.name}
-                    className="w-full h-full object-cover transition-transform duration-600 group-hover:scale-[1.04]"
-                />
+            <div className="relative aspect-video overflow-hidden bg-[#EDE9DF]">
+                {image && (
+                    <img
+                        src={image}
+                        alt={route.name}
+                        className="w-full h-full object-cover transition-transform duration-600 group-hover:scale-[1.04]"
+                    />
+                )}
                 <div className="absolute inset-0 bg-linear-to-b from-transparent to-black/25 pointer-events-none" />
 
                 {/* Admin hide button */}


### PR DESCRIPTION
  In precedenza, quando veniva calcolato e salvato un percorso, l'app switchava temporaneamente la mappa in modalità
  satellite, catturava uno screenshot con html2canvas, e poi tornava al layer precedente. Questo causava un flash
  visibile del satellite sullo schermo, rendendo l'app lenta e confusa, l'utente si ritrovava la modalità satellite
  attivata senza averla scelta.

  Inoltre lo screenshot risultava spesso decentrato o completamente vuoto, a causa di restrizioni CORS sui tile ArcGIS
  (OpaqueResponseBlocking), che impedivano a html2canvas di leggere i pixel dei tile.

  Problema separato: cliccando "Vai al Percorso" da MyTours/Tour, il percorso veniva caricato correttamente, ma la mappa
   si spostava sulla posizione GPS dell'utente invece di centrare sui bounds del percorso.

  Cosa è cambiato:

  - Lo screenshot non tocca più la mappa visibile. Viene chiamato direttamente l'endpoint di export statico di ArcGIS
  con il bounding box esatto del percorso, l'immagine satellite viene scaricata e la polyline del percorso viene
  disegnata sopra tramite Canvas API. Il risultato è sempre perfettamente centrato, senza bisogno di istanze Leaflet o
  html2canvas.
  - Rimossa la dipendenza html2canvas.
  - MapAutoCenter ora non esegue il fly-to sulla posizione GPS se è già caricato un percorso, quindi navigando da un
  tour salvato la mappa centra correttamente sul percorso.
  - Aggiunto crossOrigin="anonymous" al TileLayer satellite, così i tile vengono sempre richiesti con CORS headers,
  risolvendo il problema OpaqueResponseBlocking.